### PR TITLE
Update IOSMOEGDXFacebook.java

### DIFF
--- a/ios-moe/src/de/tomgrill/gdxfacebook/iosmoe/IOSMOEGDXFacebook.java
+++ b/ios-moe/src/de/tomgrill/gdxfacebook/iosmoe/IOSMOEGDXFacebook.java
@@ -68,7 +68,7 @@ public class IOSMOEGDXFacebook extends GDXFacebookBasic {
         loadAccessToken();
 
         if (accessToken == null && FBSDKAccessToken.currentAccessToken() != null) {
-            accessToken = new GDXFacebookAccessToken(FBSDKAccessToken.currentAccessToken().tokenString(), (long) FBSDKAccessToken.currentAccessToken().expirationDate().timeIntervalSince1970());
+            accessToken = new GDXFacebookAccessToken(FBSDKAccessToken.currentAccessToken().tokenString(), (long) FBSDKAccessToken.currentAccessToken().expirationDate().timeIntervalSince1970() * 1000);
         }
 
         if (accessToken != null) {


### PR DESCRIPTION
timeIntervalSince1970() returns time in seconds, not in milliseconds like the other platforms. This can cause confusions